### PR TITLE
⚡ Bolt: Optimize GitHub Stats Fetching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -231,12 +231,10 @@ const HomePage = ({
 
                 try {
                     // Use parallel fetching with explicit token to avoid singleton race conditions
-                    // Also use optimized count-only fetch for PRs instead of fetching full list
-                    const [issues, prCount] = await Promise.all([
-                        githubService.getOpenIssueCount(repo.owner, repo.name, token),
-                        githubService.getOpenPullRequestCount(repo.owner, repo.name, token)
-                    ]);
-                    stats[repo.id] = { issues, prs: prCount };
+                    // Optimized to use getRepositoryStats which combines repos.get (cheap) and search (expensive)
+                    // to reduce API rate limit usage.
+                    const { issues, prs } = await githubService.getRepositoryStats(repo.owner, repo.name, token);
+                    stats[repo.id] = { issues, prs };
                 } catch (error) {
                     console.error(`Failed to fetch stats for ${repo.owner}/${repo.name}`, error);
                     errors[repo.id] = describeGithubError(error);


### PR DESCRIPTION
💡 What: Implemented `getRepositoryStats` in `githubService.ts` to fetch repository details and PR counts in parallel, then deriving issue counts. Refactored `App.tsx` to use this new method.
🎯 Why: The previous implementation made 2 expensive Search API calls per repository to get issue and PR counts. This quickly exhausted the GitHub Search API rate limit (30 requests/min).
📊 Impact: Reduces Search API usage by 50% (from 2 calls/repo to 1 call/repo). Uses standard `repos.get` API (5000 requests/hr) for the second data point. Doubles the number of repositories that can be loaded on the dashboard before hitting rate limits.
🔬 Measurement: Verified using a script comparing `repos.get(open_issues_count)` vs independent Search API counts. Confirmed `open_issues_count` includes PRs, validating the subtraction logic.

---
*PR created automatically by Jules for task [3324848376226089403](https://jules.google.com/task/3324848376226089403) started by @DamienLove*