### PR TITLE
🛡️ Sentinel: Update .gitignore to exclude credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,12 @@ androidApp/signing/*.jar
 *.sw?
 /LastPrompt.txt
 /uibug.jpg
+
+# Security / Secrets
+serviceAccountKey.json
+*.jks
+*.keystore
+*.p12
+*.der
+*.key
+*.pem

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** User inputs lacked `maxLength` attributes, allowing potentially unlimited character input. This poses a Denial of Service (DoS) risk (client-side freezing, large payload transmission) and API errors when exceeding backend limits.
 **Learning:** React does not automatically enforce input limits. Explicit `maxLength` attributes are a simple, high-impact defense-in-depth measure.
 **Prevention:** Added `maxLength` to all `input` and `textarea` elements in `App.tsx` matching downstream API constraints.
+
+## 2025-02-13 - Credential Exposure Prevention (Git)
+**Vulnerability:** A local utility script (`create-user-profile.js`) required a `serviceAccountKey.json` which was not excluded from git.
+**Learning:** Utility scripts often require high-privilege credentials that are not part of the standard build process. These can easily be committed if not explicitly ignored, even if they aren't in the standard `.env` path.
+**Prevention:** Added `serviceAccountKey.json` and patterns for cryptographic keys (`*.jks`, `*.keystore`, `*.p12`, `*.key`, `*.pem`) to `.gitignore` to prevent accidental exposure of administrative credentials and signing keys.


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/MEDIUM] Fix potential credential leakage

🚨 Severity: CRITICAL
💡 Vulnerability: The `create-user-profile.js` utility script references `serviceAccountKey.json`, which was not ignored by git. Accidental commit of this file would leak administrative credentials.
🎯 Impact: Attackers could gain full administrative access to the Firebase project.
🔧 Fix: Updated `.gitignore` to explicitly exclude `serviceAccountKey.json` and standard cryptographic key formats.
✅ Verification: Ran `git check-ignore` on dummy files to confirm they are ignored.

---
*PR created automatically by Jules for task [11112543884658094684](https://jules.google.com/task/11112543884658094684) started by @DamienLove*