### PR TITLE
🎨 Palette: Improve Theme Picker Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-29 - Custom Radio Group Accessibility
+**Learning:** Custom interactive controls (like color pickers) must explicitly implement the Radio Group pattern (role='radiogroup' + role='radio') to be accessible to screen readers, as they don't use native `<input type='radio'>` elements.
+**Action:** Always verify `role="radio"` and `aria-checked` are present on custom selection components.

--- a/App.tsx
+++ b/App.tsx
@@ -570,11 +570,14 @@ const ConfigurationPage = ({
                                 </button>
                             </div>
                             <div className="space-y-2 qavt-theme-picker">
-                                <label className="text-sm font-medium text-slate-900 dark:text-white">Theme Color</label>
-                                <div className="grid grid-cols-5 gap-3 qavt-theme-grid">
+                                <label id="theme-label" className="text-sm font-medium text-slate-900 dark:text-white">Theme Color</label>
+                                <div role="radiogroup" aria-labelledby="theme-label" className="grid grid-cols-5 gap-3 qavt-theme-grid">
                                     {themes.map(t => (
                                         <button
                                             key={t.id}
+                                            role="radio"
+                                            aria-checked={currentTheme === t.id}
+                                            aria-label={t.name}
                                             onClick={() => changeTheme(t.id)}
                                             className={`qavt-theme-swatch w-full aspect-square rounded-lg border-2 ${currentTheme === t.id ? 'border-slate-900 dark:border-white scale-110' : 'border-transparent'} transition-all shadow-sm`}
                                             style={{ backgroundColor: t.colors.primary }}


### PR DESCRIPTION
💡 **What:**
Improved the accessibility of the Theme Picker component in the Configuration Page by implementing the standard ARIA Radio Group pattern.

🎯 **Why:**
The previous implementation used generic buttons without semantic grouping or state information, making it difficult for screen reader users to understand that they were selecting a single option from a set of mutually exclusive themes.

♿ **Accessibility:**
- Added `role="radiogroup"` to the button container.
- Linked the "Theme Color" label to the group using `aria-labelledby`.
- Added `role="radio"` to each theme button.
- Added `aria-checked` to indicate the selected theme.
- Added `aria-label` to provide the theme name (e.g., "Pulse Green") to assistive technologies.

📸 **Before/After:**
Visual appearance remains identical (no CSS changes).
**Before:** Screen reader announced "Button".
**After:** Screen reader announces "Pulse Green, radio button, checked, 1 of 15" (varies by screen reader).

---
*PR created automatically by Jules for task [4625981397171197382](https://jules.google.com/task/4625981397171197382) started by @DamienLove*