### PR TITLE
⚡ Bolt: Optimize GitHub Repository Stats Fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2024-05-22 - GitHub API Rate Limit Optimization
 **Learning:** GitHub's `repos.get` endpoint returns `open_issues_count` which includes both Issues and PRs. By combining this cheap call with a single Search API call for PRs, we can derive the Issue count without a second expensive Search call.
 **Action:** Use `getRepositoryStats` pattern instead of separate `getOpenIssueCount` and `getOpenPullRequestCount` calls when both are needed.
+
+## 2024-05-22 - Pre-existing Type Errors
+**Learning:** `App.tsx` contains pre-existing `TS2345` errors regarding `Set<unknown>` not being assignable to `Set<string>`. These errors do not block `vite build` or runtime, but show up in `tsc`.
+**Action:** Ignore `TS2345` errors in `App.tsx` related to `Set` unless touching that specific code block.

--- a/App.tsx
+++ b/App.tsx
@@ -230,13 +230,10 @@ const HomePage = ({
                 }
 
                 try {
-                    // Use parallel fetching with explicit token to avoid singleton race conditions
-                    // Also use optimized count-only fetch for PRs instead of fetching full list
-                    const [issues, prCount] = await Promise.all([
-                        githubService.getOpenIssueCount(repo.owner, repo.name, token),
-                        githubService.getOpenPullRequestCount(repo.owner, repo.name, token)
-                    ]);
-                    stats[repo.id] = { issues, prs: prCount };
+                    // Optimized fetching: get both stats in one go
+                    // Uses repos.get (Issues+PRs) and one search (PRs) to save rate limits
+                    const result = await githubService.getRepositoryStats(repo.owner, repo.name, token);
+                    stats[repo.id] = result;
                 } catch (error) {
                     console.error(`Failed to fetch stats for ${repo.owner}/${repo.name}`, error);
                     errors[repo.id] = describeGithubError(error);


### PR DESCRIPTION
* 💡 What: Replaced separate API calls for Issue and PR counts with a single `getRepositoryStats` method.
* 🎯 Why: To reduce GitHub Search API usage (which has a strict rate limit) by leveraging the cheaper `repos.get` endpoint.
* 📊 Impact: Reduces Search API calls by 50% per repository on the Dashboard home page.
* 🔬 Measurement: Verify that `open_issues_count` from `repos.get` minus `pr_count` from search matches the actual issue count.

---
*PR created automatically by Jules for task [2331243424208950713](https://jules.google.com/task/2331243424208950713) started by @DamienLove*