### PR TITLE
🛡️ Sentinel: [HIGH] Add API rate limiting and timeouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** User inputs lacked `maxLength` attributes, allowing potentially unlimited character input. This poses a Denial of Service (DoS) risk (client-side freezing, large payload transmission) and API errors when exceeding backend limits.
 **Learning:** React does not automatically enforce input limits. Explicit `maxLength` attributes are a simple, high-impact defense-in-depth measure.
 **Prevention:** Added `maxLength` to all `input` and `textarea` elements in `App.tsx` matching downstream API constraints.
+
+## 2024-05-27 - Context-Unaware Caching
+**Vulnerability:** API responses (Pull Requests) were cached using only the repository identifier as the key. This meant that if a privileged user fetched data, it could be served to a subsequent unprivileged user accessing the same repository, leading to information disclosure.
+**Learning:** Caching strategies must include the security context (e.g., authentication token or user ID) in the cache key, or disable caching when the context varies.
+**Prevention:** Modified `githubService` to bypass the cache whenever a custom token is provided, ensuring that cached data is only used for the default context.


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Add API rate limiting and timeouts

**Vulnerability:** The application lacked rate limiting on the client-side for GitHub API calls, allowing potentially excessive requests (DoS/Quota exhaustion). It also lacked timeouts, meaning network issues could cause the application to hang indefinitely.

**Fix:**
- Implemented in-memory caching with a 10s TTL for `getIssues` and `getPullRequests` in `services/githubService.ts`.
- Configured a 15-second timeout for all Octokit requests.
- **Security hardening:** Ensured `getPullRequests` bypasses the cache if a custom token is provided, preventing data leakage between different security contexts (e.g. repo token vs global token).

**Verification:**
- Verified logic with a standalone script (simulating hits/misses).
- Verified integration via `pnpm build`.
- Confirmed type safety via `tsc`.

**Impact:**
- Prevents API spamming.
- Improves application resilience against network issues.
- Prevents potential information disclosure via shared cache.

---
*PR created automatically by Jules for task [15549904976958148839](https://jules.google.com/task/15549904976958148839) started by @DamienLove*