### PR TITLE
🛡️ Sentinel: Add Permissions-Policy and strict input validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** User inputs lacked `maxLength` attributes, allowing potentially unlimited character input. This poses a Denial of Service (DoS) risk (client-side freezing, large payload transmission) and API errors when exceeding backend limits.
 **Learning:** React does not automatically enforce input limits. Explicit `maxLength` attributes are a simple, high-impact defense-in-depth measure.
 **Prevention:** Added `maxLength` to all `input` and `textarea` elements in `App.tsx` matching downstream API constraints.
+
+## 2024-05-24 - Permissions-Policy and Input Validation
+**Vulnerability:** The application lacked a `Permissions-Policy` header, leaving potentially sensitive browser features (camera, mic) accessible if XSS occurred. Also, input validation for `displayName` and `githubToken` relied solely on client-side `maxLength` attributes, which can be bypassed.
+**Learning:** React's controlled inputs respect `maxLength`, but logic-side validation is crucial for defense-in-depth, especially before persisting data to Firestore. `Permissions-Policy` provides a robust mechanism to disable unused features.
+**Prevention:** Added `Permissions-Policy` header to `firebase.json` and explicit length checks in `App.tsx`'s `saveRepo` function.

--- a/App.tsx
+++ b/App.tsx
@@ -456,6 +456,16 @@ const ConfigurationPage = ({
             return;
         }
 
+        // Sentinel Fix: Validate lengths to enforce logic constraints
+        if (formData.displayName && formData.displayName.length > 100) {
+             setSaveError('Display name must be 100 characters or less.');
+             return;
+        }
+        if (formData.githubToken && formData.githubToken.length > 512) {
+             setSaveError('Token is too long.');
+             return;
+        }
+
         // Validate Token (no whitespace)
         if (formData.useCustomToken !== false && formData.githubToken) {
             if (/\s/.test(formData.githubToken)) {

--- a/firebase.json
+++ b/firebase.json
@@ -37,6 +37,10 @@
           {
             "key": "Content-Security-Policy",
             "value": "default-src 'self'; script-src 'self' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com; connect-src 'self' https://api.github.com https://generativelanguage.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://www.googleapis.com; object-src 'none'; base-uri 'self';"
+          },
+          {
+            "key": "Permissions-Policy",
+            "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=()"
           }
         ]
       }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `Permissions-Policy` header allowing unrestricted access to sensitive browser features (camera, mic). Also, input validation for `displayName` and `githubToken` relied solely on client-side `maxLength`, which can be bypassed.
🎯 Impact: Reduced attack surface by disabling unused powerful features. Prevents logic-side bypass of input length constraints.
🔧 Fix: Added `Permissions-Policy` to `firebase.json` and explicit length checks in `App.tsx` `saveRepo`.
✅ Verification: `pnpm build` passes. Manual code verification confirming logic placement.

---
*PR created automatically by Jules for task [2454510532496497051](https://jules.google.com/task/2454510532496497051) started by @DamienLove*