### PR TITLE
⚡ Bolt: Optimize GitHub repository stats fetching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -232,11 +232,8 @@ const HomePage = ({
                 try {
                     // Use parallel fetching with explicit token to avoid singleton race conditions
                     // Also use optimized count-only fetch for PRs instead of fetching full list
-                    const [issues, prCount] = await Promise.all([
-                        githubService.getOpenIssueCount(repo.owner, repo.name, token),
-                        githubService.getOpenPullRequestCount(repo.owner, repo.name, token)
-                    ]);
-                    stats[repo.id] = { issues, prs: prCount };
+                    const repoStats = await githubService.getRepositoryStats(repo.owner, repo.name, token);
+                    stats[repo.id] = repoStats;
                 } catch (error) {
                     console.error(`Failed to fetch stats for ${repo.owner}/${repo.name}`, error);
                     errors[repo.id] = describeGithubError(error);


### PR DESCRIPTION
💡 **What:** Implemented `getRepositoryStats` in `services/githubService.ts` to fetch repository issue and PR counts more efficiently. Updated `App.tsx` to use this new method.

🎯 **Why:** The previous implementation used two separate calls to the GitHub Search API (`is:issue` and `is:pr`) for each repository. The Search API has a strict rate limit (30 requests/minute). Fetching statistics for multiple repositories could quickly exhaust this limit.

📊 **Impact:**
- **Reduces Search API calls by 50% per repository refresh.**
- Uses the cheaper Core API (`repos.get`, 5000 requests/hour) for the base count.
- Doubles the theoretical capacity for simultaneous repository status checks.

🔬 **Measurement:**
Verified correctness using a standalone script that mocked the Octokit response, confirming that:
1. `repos.get` is called once.
2. `search` is called exactly once (for PRs).
3. The issue count is correctly derived as `total_open_items - pr_count`.

---
*PR created automatically by Jules for task [17632773565786287515](https://jules.google.com/task/17632773565786287515) started by @DamienLove*