### PR TITLE
⚡ Bolt: Optimize repository stats fetching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -232,11 +232,8 @@ const HomePage = ({
                 try {
                     // Use parallel fetching with explicit token to avoid singleton race conditions
                     // Also use optimized count-only fetch for PRs instead of fetching full list
-                    const [issues, prCount] = await Promise.all([
-                        githubService.getOpenIssueCount(repo.owner, repo.name, token),
-                        githubService.getOpenPullRequestCount(repo.owner, repo.name, token)
-                    ]);
-                    stats[repo.id] = { issues, prs: prCount };
+                    const repoStats = await githubService.getRepositoryStats(repo.owner, repo.name, token);
+                    stats[repo.id] = repoStats;
                 } catch (error) {
                     console.error(`Failed to fetch stats for ${repo.owner}/${repo.name}`, error);
                     errors[repo.id] = describeGithubError(error);


### PR DESCRIPTION
* 💡 **What**: Implemented `getRepositoryStats` in `githubService` which uses `repos.get` (includes PRs count) and `search` (for PRs) to calculate issue count, replacing two separate search calls. Added `repoStatsCache` for caching this composite result. Updated `App.tsx` (HomePage) to use this new method.
* 🎯 **Why**: To reduce GitHub API rate limit usage and improve latency by substituting an expensive Search API call with a cheaper REST API call.
* 📊 **Impact**: Reduces Search API calls by 50% for repository stats (from 2 to 1 per repo).
* 🔬 **Measurement**: Verified logic via standalone script and type checked.

---
*PR created automatically by Jules for task [9116545790043173919](https://jules.google.com/task/9116545790043173919) started by @DamienLove*