### PR TITLE
🎨 Palette: Add "No Pull Requests" empty state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-25 - Persistent Bottom Navigation State
 **Learning:** For apps with a persistent bottom bar, relying on hardcoded active states confuses users when navigating to "secondary" top-level pages (like Config). Users expect the navigation bar to accurately reflect their location.
 **Action:** Use `useLocation` to dynamically determine the active tab in global navigation components. Ensure persistent navigation elements remain visible on all top-level destinations to prevent "dead ends".
+
+## 2024-05-26 - Empty States in Tabbed Views
+**Learning:** In tabbed interfaces (like Dashboard), ensuring every tab has an explicit empty state is crucial. Missing this leads to "blank screen anxiety" where users suspect a bug.
+**Action:** When implementing tabbed lists, always check `length === 0` and render a consistent empty state component (icon + title + helper text).

--- a/App.tsx
+++ b/App.tsx
@@ -2049,6 +2049,13 @@ const Dashboard = ({ repos, user, globalSettings, onNotesClick }: { repos: Repos
                 {!loading && tab === 'prs' && (
                     <div className="space-y-3">
                         {prError && <div className="rounded-lg border border-red-500/30 bg-red-500/10 text-red-200 text-xs px-3 py-2">{prError}</div>}
+                        {prs.length === 0 && !prError ? (
+                            <div className="text-center py-20 opacity-50">
+                                <span className="material-symbols-outlined text-6xl text-gray-600 mb-4" aria-hidden="true">source_notes</span>
+                                <p className="text-lg font-bold text-gray-500 dark:text-gray-400">No Open Pull Requests</p>
+                                <p className="text-sm text-gray-400">All caught up! Sync to check for updates.</p>
+                            </div>
+                        ) : null}
                         {prs.length > 0 && (
                             <div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-surface-dark-lighter/80 p-3 shadow-sm">
                                 <div className="flex items-center gap-3">


### PR DESCRIPTION
Added a helpful empty state with icon and helper text to the Pull Requests tab in the Dashboard when no PRs are present. This prevents users from seeing a confusing blank screen. Also added a journal entry documenting the importance of empty states in tabbed views.

♿ Accessibility: Added `aria-hidden="true"` to decorative icons.

---
*PR created automatically by Jules for task [15533189778592137781](https://jules.google.com/task/15533189778592137781) started by @DamienLove*