### PR TITLE
⚡ Bolt: Optimize repository stats fetching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -232,11 +232,8 @@ const HomePage = ({
                 try {
                     // Use parallel fetching with explicit token to avoid singleton race conditions
                     // Also use optimized count-only fetch for PRs instead of fetching full list
-                    const [issues, prCount] = await Promise.all([
-                        githubService.getOpenIssueCount(repo.owner, repo.name, token),
-                        githubService.getOpenPullRequestCount(repo.owner, repo.name, token)
-                    ]);
-                    stats[repo.id] = { issues, prs: prCount };
+                    const repoStats = await githubService.getRepositoryStats(repo.owner, repo.name, token);
+                    stats[repo.id] = repoStats;
                 } catch (error) {
                     console.error(`Failed to fetch stats for ${repo.owner}/${repo.name}`, error);
                     errors[repo.id] = describeGithubError(error);


### PR DESCRIPTION
💡 What: Implemented getRepositoryStats in githubService to fetch issue and PR counts efficiently.
🎯 Why: Separate calls to getOpenIssueCount and getOpenPullRequestCount consumed 2 search API credits per repo.
📊 Impact: Reduces Search API usage by 50% for repository stats (1 call instead of 2). Uses the cheaper REST API for total count.
🔬 Measurement: Verify dashboard loads correctly and issue/PR counts are accurate.

---
*PR created automatically by Jules for task [5479012287070314828](https://jules.google.com/task/5479012287070314828) started by @DamienLove*