### PR TITLE
🎨 Palette: Enable click-outside-to-close for Notes modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Accessibility Improvements
 **Learning:** Found several interactive elements (switches, theme pickers) lacking `aria-label`, relying solely on visual context which fails for screen readers.
 **Action:** Always check `role="switch"` and icon-only buttons for proper accessible labels.
+
+## 2024-05-24 - Modal Interaction Consistency
+**Learning:** Inconsistent modal behaviors (some close on backdrop click, others don't) confuse users. Found `QuickIssuePage` had it, but `Notes` and others didn't.
+**Action:** Standardize all modals to support "click-outside-to-close" pattern unless explicit action is required.

--- a/components/Notes.tsx
+++ b/components/Notes.tsx
@@ -49,10 +49,14 @@ const Notes = ({ isOpen, onClose, userId }: { isOpen: boolean; onClose: () => vo
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center">
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
       <div
         className="bg-surface-dark rounded-lg shadow-2xl w-full max-w-md mx-4"
         role="dialog"
+        onClick={(e) => e.stopPropagation()}
         aria-modal="true"
         aria-labelledby="notes-modal-title"
       >


### PR DESCRIPTION
💡 What: Added an onClick handler to the Notes modal backdrop to close the modal, and added stopPropagation to the modal content.
🎯 Why: Standardizes modal behavior with other parts of the app (like QuickIssuePage) and improves usability by allowing users to dismiss the modal by clicking outside.
♿ Accessibility: Maintains existing accessibility features (aria-modal, focus management).


---
*PR created automatically by Jules for task [16924606906615539176](https://jules.google.com/task/16924606906615539176) started by @DamienLove*