### PR TITLE
⚡ Bolt: Optimize repository stats fetching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -230,13 +230,9 @@ const HomePage = ({
                 }
 
                 try {
-                    // Use parallel fetching with explicit token to avoid singleton race conditions
-                    // Also use optimized count-only fetch for PRs instead of fetching full list
-                    const [issues, prCount] = await Promise.all([
-                        githubService.getOpenIssueCount(repo.owner, repo.name, token),
-                        githubService.getOpenPullRequestCount(repo.owner, repo.name, token)
-                    ]);
-                    stats[repo.id] = { issues, prs: prCount };
+                    // Use optimized combined fetch to reduce API calls (repo details + 1 search instead of 2 searches)
+                    const { issues, prs } = await githubService.getRepositoryStats(repo.owner, repo.name, token);
+                    stats[repo.id] = { issues, prs };
                 } catch (error) {
                     console.error(`Failed to fetch stats for ${repo.owner}/${repo.name}`, error);
                     errors[repo.id] = describeGithubError(error);

--- a/services/githubService.ts
+++ b/services/githubService.ts
@@ -5,6 +5,7 @@ let octokit: Octokit | null = null;
 let currentToken: string | null = null;
 const commentsCache = new Map<string, { timestamp: string; data: Comment[] }>();
 const statsCache = new Map<string, { timestamp: number; count: number }>();
+const repoStatsCache = new Map<string, { timestamp: number; data: { issues: number; prs: number } }>();
 const STATS_CACHE_TTL = 60000; // 60 seconds
 
 const decodeBase64 = (value: string) => {
@@ -189,6 +190,7 @@ export const githubService = {
     currentToken = token;
     octokit = null; // Force recreation with new token on next use
     statsCache.clear(); // Clear stats cache when switching tokens/users
+    repoStatsCache.clear();
   },
 
   getOwnerType: async (owner: string): Promise<'User' | 'Organization' | null> => {
@@ -200,6 +202,31 @@ export const githubService = {
       console.error("Failed to fetch owner type", e);
       return null;
     }
+  },
+
+  getRepositoryStats: async (owner: string, repo: string, token?: string): Promise<{ issues: number, prs: number }> => {
+    const cacheKey = `stats-${owner}-${repo}`;
+    const cached = repoStatsCache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < STATS_CACHE_TTL) {
+      return cached.data;
+    }
+
+    const api = await getOctokit(token);
+
+    // Fetch repo details (cheap call, includes combined count) and PR count (expensive search) in parallel
+    const [repoData, prCount] = await Promise.all([
+        api.repos.get({ owner, repo }),
+        githubService.getOpenPullRequestCount(owner, repo, token)
+    ]);
+
+    // open_issues_count includes both issues and PRs.
+    const totalOpen = repoData.data.open_issues_count;
+    const issuesCount = Math.max(0, totalOpen - prCount);
+
+    const result = { issues: issuesCount, prs: prCount };
+    repoStatsCache.set(cacheKey, { timestamp: Date.now(), data: result });
+
+    return result;
   },
 
   getIssueComments,


### PR DESCRIPTION
⚡ Bolt: Optimize repository stats fetching

💡 What:
Replaced parallel `getOpenIssueCount` (Search API) and `getOpenPullRequestCount` (Search API) calls with a single `getRepositoryStats` call.
`getRepositoryStats` fetches repository metadata (which includes `open_issues_count` = issues + PRs) and the PR count (via Search API), then derives the issue count.

🎯 Why:
The GitHub Search API has a strict rate limit (30 requests/minute). The previous implementation consumed 2 search requests per repository load. For a user with multiple repositories, this could quickly hit the rate limit. The `repos.get` endpoint is much cheaper (5000/hour) and faster.

📊 Impact:
Reduces Search API usage by 50% for dashboard loading.
Doubles the effective capacity for loading repository stats before hitting rate limits.

🔬 Measurement:
Verified via `tsc` for type safety.
Manual verification script confirmed `getRepositoryStats` is correctly defined and integrated.

---
*PR created automatically by Jules for task [9792547605313394430](https://jules.google.com/task/9792547605313394430) started by @DamienLove*