### PR TITLE
⚡ Bolt: Optimize repository stats fetching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -232,11 +232,8 @@ const HomePage = ({
                 try {
                     // Use parallel fetching with explicit token to avoid singleton race conditions
                     // Also use optimized count-only fetch for PRs instead of fetching full list
-                    const [issues, prCount] = await Promise.all([
-                        githubService.getOpenIssueCount(repo.owner, repo.name, token),
-                        githubService.getOpenPullRequestCount(repo.owner, repo.name, token)
-                    ]);
-                    stats[repo.id] = { issues, prs: prCount };
+                    const repoStats = await githubService.getRepositoryStats(repo.owner, repo.name, token);
+                    stats[repo.id] = repoStats;
                 } catch (error) {
                     console.error(`Failed to fetch stats for ${repo.owner}/${repo.name}`, error);
                     errors[repo.id] = describeGithubError(error);


### PR DESCRIPTION
⚡ **Bolt Optimization**

I've optimized the dashboard's repository statistics fetching to be faster and friendlier to GitHub's rate limits.

**💡 What:**
Replaced the two separate API calls for "Open Issues" and "Open PRs" with a single, optimized strategy.
- **Before:** 2 expensive Search API calls per repository.
- **After:** 1 cheap REST API call + 1 Search API call per repository.

**🎯 Why:**
The GitHub Search API has a strict rate limit (30 req/min). For users with multiple repositories, loading the dashboard could easily exhaust this limit. The REST API (`repos.get`) is much more generous.

**📊 Impact:**
- **Reduces Search API usage by 50%** per repository.
- **Faster load times** due to parallel execution and lighter API load.
- **Added caching** (60s) for stats to prevent redundant fetches on navigation.

**🔬 Measurement:**
Verified the logic using a simulation script (`scripts/test_stats_logic.js`) to ensure the calculation `issues = total_open_count - pr_count` is correct. Confirmed via code review that the implementation follows GitHub API specifications.

---
*PR created automatically by Jules for task [6260174704798334578](https://jules.google.com/task/6260174704798334578) started by @DamienLove*