### PR TITLE
🎨 Palette: Improved Notes Modal UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Accessibility Improvements
 **Learning:** Found several interactive elements (switches, theme pickers) lacking `aria-label`, relying solely on visual context which fails for screen readers.
 **Action:** Always check `role="switch"` and icon-only buttons for proper accessible labels.
+
+## 2026-02-04 - Modal Interaction Pattern
+**Learning:** Standardized "click-outside-to-close" using backdrop onClick + content stopPropagation.
+**Action:** Apply this pattern to all future modals (BlockIssue, ConflictPr) for consistency.

--- a/components/Notes.tsx
+++ b/components/Notes.tsx
@@ -49,9 +49,10 @@ const Notes = ({ isOpen, onClose, userId }: { isOpen: boolean; onClose: () => vo
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center" onClick={onClose}>
       <div
-        className="bg-surface-dark rounded-lg shadow-2xl w-full max-w-md mx-4"
+        className="bg-surface-dark rounded-lg shadow-2xl w-full max-w-md mx-4 animate-fade-in"
+        onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-labelledby="notes-modal-title"


### PR DESCRIPTION
Implemented a "click outside to close" behavior for the Notes modal to improve usability. 
Added a fade-in animation for a smoother user experience.
Verified with Playwright script ensuring the modal closes correctly when the backdrop is clicked.

---
*PR created automatically by Jules for task [2734133448337851387](https://jules.google.com/task/2734133448337851387) started by @DamienLove*